### PR TITLE
Fixed utils.ts for the incorrect mapping of the name and mime

### DIFF
--- a/packages/nodes-base/nodes/Discord/test/v2/utils.test.ts
+++ b/packages/nodes-base/nodes/Discord/test/v2/utils.test.ts
@@ -1,4 +1,4 @@
-import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import type { IExecuteFunctions, INode, INodeExecutionData, IBinaryKeyData } from 'n8n-workflow';
 
 import * as transport from '../../v2//transport/discord.api';
 import {
@@ -7,6 +7,7 @@ import {
 	prepareEmbeds,
 	checkAccessToGuild,
 	setupChannelGetter,
+	prepareMultiPartForm,
 } from '../../v2/helpers/utils';
 
 const node: INode = {
@@ -152,5 +153,169 @@ describe('Test Discord > setupChannelGetter & checkAccessToChannel', () => {
 		const getChannel = await setupChannelGetter.call(fakeExecuteFunction('botToken'), userGuilds);
 		const channelId = await getChannel(0);
 		expect(channelId).toBe('42');
+	});
+});
+
+describe('Test Discord > prepareMultiPartForm', () => {
+	const mockBinaryData = Buffer.from('test file content');
+	
+	const mockExecuteFunctions = {
+		getNode: () => node,
+		helpers: {
+			getBinaryDataBuffer: jest.fn().mockResolvedValue(mockBinaryData),
+		},
+	} as unknown as IExecuteFunctions;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should correctly map contentType and filename in multipart form', async () => {
+		const items: INodeExecutionData[] = [
+			{
+				json: {},
+				binary: <IBinaryKeyData>{
+					file1: {
+						fileName: 'test-document.pdf',
+						mimeType: 'application/pdf',
+						fileExtension: 'pdf',
+						data: 'base64data',
+					},
+				},
+			},
+		];
+
+		const files = [{ inputFieldName: 'file1' }];
+		const jsonPayload = { content: 'Test message' };
+
+		const result = await prepareMultiPartForm.call(mockExecuteFunctions, items, files, jsonPayload, 0);
+
+		expect(result).toBeDefined();
+		expect(mockExecuteFunctions.helpers.getBinaryDataBuffer).toHaveBeenCalledWith(0, 'file1');
+		
+		// Verify the form data contains correct payload
+		const payloadJson = result.getBuffer('payload_json');
+		expect(payloadJson).toBeDefined();
+		
+		const payload = JSON.parse(payloadJson.toString());
+		expect(payload.content).toBe('Test message');
+		expect(payload.attachments).toEqual([
+			{
+				id: 0,
+				filename: 'test-document.pdf',
+			},
+		]);
+	});
+
+	it('should handle files without extension by adding it from mimeType', async () => {
+		const items: INodeExecutionData[] = [
+			{
+				json: {},
+				binary: <IBinaryKeyData>{
+					file1: {
+						fileName: 'document',
+						mimeType: 'image/png',
+						data: 'base64data',
+					},
+				},
+			},
+		];
+
+		const files = [{ inputFieldName: 'file1' }];
+		const jsonPayload = { content: 'Test message' };
+
+		const result = await prepareMultiPartForm.call(mockExecuteFunctions, items, files, jsonPayload, 0);
+
+		const payloadJson = result.getBuffer('payload_json');
+		const payload = JSON.parse(payloadJson.toString());
+		
+		expect(payload.attachments[0].filename).toBe('document.png');
+	});
+
+	it('should handle files with fileExtension property', async () => {
+		const items: INodeExecutionData[] = [
+			{
+				json: {},
+				binary: <IBinaryKeyData>{
+					file1: {
+						fileName: 'document',
+						mimeType: 'application/pdf',
+						fileExtension: 'pdf',
+						data: 'base64data',
+					},
+				},
+			},
+		];
+
+		const files = [{ inputFieldName: 'file1' }];
+		const jsonPayload = { content: 'Test message' };
+
+		const result = await prepareMultiPartForm.call(mockExecuteFunctions, items, files, jsonPayload, 0);
+
+		const payloadJson = result.getBuffer('payload_json');
+		const payload = JSON.parse(payloadJson.toString());
+		
+		expect(payload.attachments[0].filename).toBe('document.pdf');
+	});
+
+	it('should throw error when binary data is missing', async () => {
+		const items: INodeExecutionData[] = [
+			{
+				json: {},
+				binary: <IBinaryKeyData>{},
+			},
+		];
+
+		const files = [{ inputFieldName: 'file1' }];
+		const jsonPayload = { content: 'Test message' };
+
+		await expect(
+			prepareMultiPartForm.call(mockExecuteFunctions, items, files, jsonPayload, 0)
+		).rejects.toThrow('Input item [0] does not contain binary data on property file1');
+	});
+
+	it('should handle multiple files with correct contentType and filename mapping', async () => {
+		const items: INodeExecutionData[] = [
+			{
+				json: {},
+				binary: <IBinaryKeyData>{
+					file1: {
+						fileName: 'document.pdf',
+						mimeType: 'application/pdf',
+						data: 'base64data1',
+					},
+					file2: {
+						fileName: 'image.jpg',
+						mimeType: 'image/jpeg',
+						data: 'base64data2',
+					},
+				},
+			},
+		];
+
+		const files = [
+			{ inputFieldName: 'file1' },
+			{ inputFieldName: 'file2' },
+		];
+		const jsonPayload = { content: 'Test message with multiple files' };
+
+		const result = await prepareMultiPartForm.call(mockExecuteFunctions, items, files, jsonPayload, 0);
+
+		const payloadJson = result.getBuffer('payload_json');
+		const payload = JSON.parse(payloadJson.toString());
+		
+		expect(payload.attachments).toHaveLength(2);
+		expect(payload.attachments[0]).toEqual({
+			id: 0,
+			filename: 'document.pdf',
+		});
+		expect(payload.attachments[1]).toEqual({
+			id: 1,
+			filename: 'image.jpg',
+		});
+		
+		expect(mockExecuteFunctions.helpers.getBinaryDataBuffer).toHaveBeenCalledTimes(2);
+		expect(mockExecuteFunctions.helpers.getBinaryDataBuffer).toHaveBeenCalledWith(0, 'file1');
+		expect(mockExecuteFunctions.helpers.getBinaryDataBuffer).toHaveBeenCalledWith(0, 'file2');
 	});
 });

--- a/packages/nodes-base/nodes/Discord/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Discord/v2/helpers/utils.ts
@@ -221,8 +221,8 @@ export async function prepareMultiPartForm(
 
 	for (const [index, binaryData] of filesData.entries()) {
 		multiPartBody.append(`files[${index}]`, binaryData.data, {
-			contentType: binaryData.name as string,
-			filename: binaryData.mime as string,
+			contentType: binaryData.mime as string,
+			filename: binaryData.name as string,
 		});
 	}
 


### PR DESCRIPTION
Discord node v2 for the webhook type calls, was sending the incorrect file names in the message to discord channel. with this fix, the file will be properly named in the message.

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
