### PR TITLE
:bug: Fix WordPress Cache control on no-read operation

### DIFF
--- a/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Wordpress/GenericFunctions.ts
@@ -12,20 +12,22 @@ export async function wordpressApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
 	resource: string,
-
 	body: any = {},
 	qs: IDataObject = {},
 	uri?: string,
 	option: IDataObject = {},
 ): Promise<any> {
 	const credentials = await this.getCredentials('wordpressApi');
-
+	let headers: Record<string, string> = {
+		Accept: 'application/json',
+		'Content-Type': 'application/json',
+		'User-Agent': 'n8n',
+	};
+	if (!['HEAD', 'GET'].includes(method)) {
+		headers['Cache-Control'] = 'no-cache';
+	}
 	let options: IRequestOptions = {
-		headers: {
-			Accept: 'application/json',
-			'Content-Type': 'application/json',
-			'User-Agent': 'n8n',
-		},
+		headers,
 		method,
 		qs,
 		body,

--- a/packages/nodes-base/nodes/Wordpress/__tests__/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Wordpress/__tests__/GenericFunctions.test.ts
@@ -26,6 +26,32 @@ describe('Wordpress > GenericFunctions', () => {
 			expect(mockFunctions.helpers.requestWithAuthentication).toHaveBeenCalled();
 		});
 
+		it('should set Cache-Control set to no-cache for non-read requests', async () => {
+			mockFunctions.helpers.requestWithAuthentication.mockResolvedValue({ data: 'testData' });
+			await wordpressApiRequest.call(mockFunctions, 'POST', '/posts', {}, {});
+			expect(mockFunctions.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+				'wordpressApi',
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						'Cache-Control': 'no-cache',
+					}),
+				}),
+			);
+		});
+
+		it('should not set Cache-Control for GET requests', async () => {
+			mockFunctions.helpers.requestWithAuthentication.mockResolvedValue({ data: 'testData' });
+			await wordpressApiRequest.call(mockFunctions, 'GET', '/posts', {}, {});
+			expect(mockFunctions.helpers.requestWithAuthentication).toHaveBeenCalledWith(
+				'wordpressApi',
+				expect.objectContaining({
+					headers: expect.not.objectContaining({
+						'Cache-Control': 'no-cache',
+					}),
+				}),
+			);
+		});
+
 		it('should throw NodeApiError on failure', async () => {
 			mockFunctions.helpers.requestWithAuthentication.mockRejectedValue({ message: 'fail' });
 			await expect(


### PR DESCRIPTION
While not setting `Cache-Control`, Some cache plugins will ignore method

For example:

It returns posts list while trying to create post

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
